### PR TITLE
edits in 0-printf-str and 2-printf-binary

### DIFF
--- a/0-printf-str.c
+++ b/0-printf-str.c
@@ -15,6 +15,11 @@ int _printfstring(va_list args)
 	char *s;
 
 	s = va_arg(args, char *);
+	if (s == NULL)
+	{
+		fputs("(null)", stdout);
+		return (strlen("(null)"));
+	}
 	fputs(s, stdout);
 	return (strlen(s));
 }

--- a/2-printf-binary.c
+++ b/2-printf-binary.c
@@ -10,9 +10,9 @@
  * Return: the answer
  */
 
-int _pow_recursion(int x, int y)
+int _pow_recursion(unsigned int x, unsigned int y)
 {
-	int sum;
+	unsigned int sum;
 
 	if (y < 0)
 		return (-1);
@@ -32,30 +32,32 @@ int _pow_recursion(int x, int y)
 
 int _printfbin(va_list args)
 {
-	unsigned int n;
-	int i, j, pwr, num, flag, sum;
+	unsigned int n, pwr;
+	int i, j, num, flag, sum;
 
 	n = va_arg(args, int);
 	sum = 0;
 	pwr = 0;
-	for (i = 0, flag = 0; pwr < (int)n; i++)
+	for (i = 0, flag = 0; pwr < n; i++)
 	{
+		if (n == 4294967295)
+			i = 32;
 		pwr = _pow_recursion(2, i);
-			if (pwr > (int)n)
+			if (pwr >= n || n == 4294967295)
 			{
 				flag = 1;
-				num = n - (_pow_recursion(2, (i - 1)));
+				num = (pwr == n) ? (n - pwr) : (n - _pow_recursion(2, (i - 1)));
 				putchar('1');
 				sum++;
-				for (j = i - 2; j >= 0; j--)
+				for (j = (num == 0) ? i - 1 : i - 2; j >= 0; j--)
 				{
 					pwr = _pow_recursion(2, j);
-					if (num < pwr)
+					if (num <(int) pwr)
 					{
 						putchar('0');
 						sum++;
 					}
-					if (num >= pwr)
+					if (num >= (int)pwr)
 					{
 						num = num - pwr;
 						putchar('1');

--- a/main.h
+++ b/main.h
@@ -25,6 +25,6 @@ int _printfchar(va_list args);
 int _printfint(va_list args);
 int recursive_int(int n);
 int _printfbin(va_list args);
-int _pow_recursion(int x, int y);
+int _pow_recursion(unsigned int x, unsigned int y);
 
 #endif


### PR DESCRIPTION
2-printf-binary: this file had a lot of issues to handle the conversion of numbers to binary, related to logic and interpretation technique, all were modified and tested already to match most of the test arguments.

1-printf-str: this file couldn't handle cases where the argument is NULL, so a modification was made to insure correct behavior.
